### PR TITLE
Move the weeding visitors to weeder package.

### DIFF
--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -1,10 +1,10 @@
 #include "base/unique_ptr_vector.h"
 #include "lexer/lexer.h"
-#include "parser/assignment_visitor.h"
 #include "parser/ast.h"
-#include "parser/call_visitor.h"
 #include "parser/parser_internal.h"
 #include "parser/print_visitor.h"
+#include "weeder/assignment_visitor.h"
+#include "weeder/call_visitor.h"
 
 using base::Error;
 using base::ErrorList;
@@ -1019,11 +1019,12 @@ Parser Parser::ParseForStmt(Result<Stmt>* out) const {
   return next.Fail(move(errors), out);
 }
 
+// TODO: move Weed function to weeder package.
 void Weed(const FileSet* fs, Stmt* stmt, ErrorList* out) {
-  AssignmentVisitor assignmentChecker(fs, out);
+  weeder::AssignmentVisitor assignmentChecker(fs, out);
   stmt->Accept(&assignmentChecker);
 
-  CallVisitor callChecker(fs, out);
+  weeder::CallVisitor callChecker(fs, out);
   stmt->Accept(&callChecker);
 
   // More weeding required.

--- a/parser/parser_test.cpp
+++ b/parser/parser_test.cpp
@@ -1,6 +1,4 @@
 #include "lexer/lexer.h"
-#include "parser/assignment_visitor.h"
-#include "parser/call_visitor.h"
 #include "parser/parser_internal.h"
 #include "parser/print_visitor.h"
 #include "third_party/gtest/gtest.h"
@@ -1094,92 +1092,6 @@ TEST_F(ParserTest, ForStmtPropagateErrorFromBody) {
   EXPECT_FALSE(b(after));
   EXPECT_FALSE(b(stmt));
   EXPECT_EQ("UnexpectedTokenError(0:9)\n", testing::PrintToString(stmt.Errors()));
-}
-
-TEST_F(ParserTest, AssignmentVisitorName) {
-  MakeParser("a = 1;");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  AssignmentVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_FALSE(errors.IsFatal());
-}
-
-TEST_F(ParserTest, AssignmentVisitorFieldDeref) {
-  MakeParser("this.f = 1;");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  AssignmentVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_FALSE(errors.IsFatal());
-}
-
-TEST_F(ParserTest, AssignmentVisitorArrayIndex) {
-  MakeParser("a[0] = 1;");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  AssignmentVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_FALSE(errors.IsFatal());
-}
-
-TEST_F(ParserTest, AssignmentVisitorFail) {
-  MakeParser("a() = 1;");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  AssignmentVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_TRUE(errors.IsFatal());
-  EXPECT_EQ("InvalidLHSError(0:4)\n", testing::PrintToString(errors));
-}
-
-TEST_F(ParserTest, CallVisitorName) {
-  MakeParser("a(1);");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  CallVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_FALSE(errors.IsFatal());
-}
-
-TEST_F(ParserTest, CallVisitorFieldDeref) {
-  MakeParser("this.a(1);");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  CallVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_FALSE(errors.IsFatal());
-}
-
-TEST_F(ParserTest, CallVisitorFail) {
-  MakeParser("a()();");
-  Result<Stmt> stmt;
-  ASSERT_TRUE(b(parser_->ParseStmt(&stmt)));
-
-  ErrorList errors;
-  CallVisitor visitor(fs_.get(), &errors);
-  stmt.Get()->Accept(&visitor);
-
-  EXPECT_TRUE(errors.IsFatal());
-  EXPECT_EQ("InvalidCallError(0:3)\n", testing::PrintToString(errors));
 }
 
 } // namespace parser

--- a/parser/recursive_visitor.h
+++ b/parser/recursive_visitor.h
@@ -85,9 +85,9 @@ protected:
 };
 
 #define REC_VISIT_DECL(type, var) \
-  bool Visit##type##Impl(const type* var) override
+  bool Visit##type##Impl(const parser::type* var) override
 #define REC_VISIT_DEFN(cls, type, var) \
-  bool cls::Visit##type##Impl(const type* var)
+  bool cls::Visit##type##Impl(const parser::type* var)
 
 } // namespace parser
 

--- a/parser/visitor.h
+++ b/parser/visitor.h
@@ -59,8 +59,10 @@ protected:
   Visitor() = default;
 };
 
-#define VISIT_DECL(type, var) void Visit##type(const type* var) override
-#define VISIT_DEFN(cls, type, var) void cls::Visit##type(const type* var)
+#define VISIT_DECL(type, var) \
+  void Visit##type(const parser::type* var) override
+#define VISIT_DEFN(cls, type, var) \
+  void cls::Visit##type(const parser::type* var)
 
 } // namespace parser
 

--- a/weeder/assignment_visitor.cpp
+++ b/weeder/assignment_visitor.cpp
@@ -1,14 +1,19 @@
 #include "base/macros.h"
 #include "lexer/lexer.h"
-#include "parser/assignment_visitor.h"
 #include "parser/ast.h"
+#include "weeder/assignment_visitor.h"
 
-using lexer::ASSG;
-using lexer::Token;
 using base::Error;
 using base::FileSet;
+using lexer::ASSG;
+using lexer::Token;
+using parser::ArrayIndexExpr;
+using parser::BinExpr;
+using parser::Expr;
+using parser::FieldDerefExpr;
+using parser::NameExpr;
 
-namespace parser {
+namespace weeder {
 
 Error* MakeInvalidLHSError(const FileSet* fs, Token token) {
   return MakeSimplePosRangeError(
@@ -32,4 +37,4 @@ REC_VISIT_DEFN(AssignmentVisitor, BinExpr, expr){
   return true;
 }
 
-} // namespace parser
+} // namespace weeder

--- a/weeder/assignment_visitor.h
+++ b/weeder/assignment_visitor.h
@@ -1,16 +1,15 @@
-#ifndef PARSER_ASSIGNMENT_VISITOR_H
-#define PARSER_ASSIGNMENT_VISITOR_H
+#ifndef WEEDER_ASSIGNMENT_VISITOR_H
+#define WEEDER_ASSIGNMENT_VISITOR_H
 
 #include "base/fileset.h"
 #include "base/errorlist.h"
 #include "parser/recursive_visitor.h"
 
-// TODO: this needs to be moved to weeder.
-namespace parser {
+namespace weeder {
 
 // AssignmentVisitor checks that the left-hand-side of an assignment is one of
 // NameExpr, FieldDerefExpr, or ArrayIndexExpr.
-class AssignmentVisitor : public RecursiveVisitor {
+class AssignmentVisitor : public parser::RecursiveVisitor {
 public:
   AssignmentVisitor(const base::FileSet* fs, base::ErrorList* errors) : fs_(fs), errors_(errors) {}
 
@@ -21,6 +20,6 @@ private:
   base::ErrorList* errors_;
 };
 
-} // namespace parser
+} // namespace weeder
 
 #endif

--- a/weeder/assignment_visitor_test.cpp
+++ b/weeder/assignment_visitor_test.cpp
@@ -1,0 +1,63 @@
+#include "weeder/assignment_visitor.h"
+#include "weeder/weeder_test.h"
+
+using base::ErrorList;
+using parser::Stmt;
+using parser::internal::Result;
+
+namespace weeder {
+
+class AssignmentVisitorTest : public WeederTest {
+};
+
+TEST_F(AssignmentVisitorTest, Name) {
+  MakeParser("a = 1;");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  AssignmentVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_FALSE(errors.IsFatal());
+}
+
+TEST_F(AssignmentVisitorTest, FieldDeref) {
+  MakeParser("this.f = 1;");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  AssignmentVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_FALSE(errors.IsFatal());
+}
+
+TEST_F(AssignmentVisitorTest, ArrayIndex) {
+  MakeParser("a[0] = 1;");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  AssignmentVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_FALSE(errors.IsFatal());
+}
+
+TEST_F(AssignmentVisitorTest, Fail) {
+  MakeParser("a() = 1;");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  AssignmentVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_TRUE(errors.IsFatal());
+  EXPECT_EQ("InvalidLHSError(0:4)\n", testing::PrintToString(errors));
+}
+
+} // namespace weeder
+

--- a/weeder/call_visitor.cpp
+++ b/weeder/call_visitor.cpp
@@ -1,12 +1,15 @@
 #include "base/macros.h"
 #include "parser/ast.h"
-#include "parser/call_visitor.h"
+#include "weeder/call_visitor.h"
 
-using lexer::Token;
 using base::Error;
 using base::FileSet;
+using lexer::Token;
+using parser::Expr;
+using parser::FieldDerefExpr;
+using parser::NameExpr;
 
-namespace parser {
+namespace weeder {
 
 Error* MakeInvalidCallError(const FileSet* fs, Token token) {
   return MakeSimplePosRangeError(
@@ -26,4 +29,4 @@ REC_VISIT_DEFN(CallVisitor, CallExpr, expr){
   return true;
 }
 
-} // namespace parser
+} // namespace weeder

--- a/weeder/call_visitor.h
+++ b/weeder/call_visitor.h
@@ -1,16 +1,15 @@
-#ifndef PARSER_CALL_VISITOR_H
-#define PARSER_CALL_VISITOR_H
+#ifndef WEEDER_CALL_VISITOR_H
+#define WEEDER_CALL_VISITOR_H
 
 #include "base/fileset.h"
 #include "base/errorlist.h"
 #include "parser/recursive_visitor.h"
 
-// TODO: this needs to be moved to weeder.
-namespace parser {
+namespace weeder {
 
 // CallVisitor checks that the left-hand-side of a method call is one of
 // NameExpr, or FieldDerefExpr.
-class CallVisitor : public RecursiveVisitor {
+class CallVisitor : public parser::RecursiveVisitor {
 public:
   CallVisitor(const base::FileSet* fs, base::ErrorList* errors) : fs_(fs), errors_(errors) {}
 
@@ -21,6 +20,6 @@ private:
   base::ErrorList* errors_;
 };
 
-} // namespace parser
+} // namespace weeder
 
 #endif

--- a/weeder/call_visitor_test.cpp
+++ b/weeder/call_visitor_test.cpp
@@ -1,0 +1,50 @@
+#include "weeder/call_visitor.h"
+#include "weeder/weeder_test.h"
+
+using base::ErrorList;
+using parser::Stmt;
+using parser::internal::Result;
+
+namespace weeder {
+
+class CallVisitorTest : public WeederTest {
+};
+
+TEST_F(CallVisitorTest, Name) {
+  MakeParser("a(1);");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  CallVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_FALSE(errors.IsFatal());
+}
+
+TEST_F(CallVisitorTest, FieldDeref) {
+  MakeParser("this.a(1);");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  CallVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_FALSE(errors.IsFatal());
+}
+
+TEST_F(CallVisitorTest, Fail) {
+  MakeParser("a()();");
+  Result<Stmt> stmt;
+  ASSERT_FALSE(parser_->ParseStmt(&stmt).Failed());
+
+  ErrorList errors;
+  CallVisitor visitor(fs_.get(), &errors);
+  stmt.Get()->Accept(&visitor);
+
+  EXPECT_TRUE(errors.IsFatal());
+  EXPECT_EQ("InvalidCallError(0:3)\n", testing::PrintToString(errors));
+}
+
+} // namespace weeder

--- a/weeder/weeder_test.h
+++ b/weeder/weeder_test.h
@@ -1,0 +1,50 @@
+#ifndef WEEDER_WEEDER_TEST_H
+#define WEEDER_WEEDER_TEST_H
+
+#include "lexer/lexer.h"
+#include "parser/parser_internal.h"
+#include "third_party/gtest/gtest.h"
+
+namespace weeder {
+
+class WeederTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    fs_.reset();
+    parser_.reset();
+  }
+
+  virtual void TearDown() {
+    fs_.reset();
+    parser_.reset();
+  }
+
+  void MakeParser(string s) {
+    base::ErrorList errors;
+
+    // Create file set.
+    base::FileSet* fs;
+    ASSERT_TRUE(base::FileSet::Builder()
+        .AddStringFile("foo.joos", s)
+        .Build(&fs, &errors));
+    fs_.reset(fs);
+
+    // Lex tokens.
+    lexer::LexJoosFiles(fs, &tokens, &errors);
+    lexer::StripSkippableTokens(&tokens[0]);
+
+    // Make sure it worked.
+    ASSERT_EQ(1u, tokens.size());
+    ASSERT_FALSE(errors.IsFatal());
+
+    parser_.reset(new parser::Parser(fs, fs->Get(0), &tokens[0]));
+  }
+
+  vector<vector<lexer::Token>> tokens;
+  unique_ptr<base::FileSet> fs_;
+  unique_ptr<parser::Parser> parser_;
+};
+
+} // namespace weeder
+
+#endif


### PR DESCRIPTION
This is purely a move; code changes only as necessary to complete the move.

Note that until the parser is completed and we stabilize its API, we include the weeders from weeder/\* and use them inside parser. This will eventually move elsewhere once the Parse() function is changed to return a parsed Program.
