### PR TITLE
Kill off useless temps.

### DIFF
--- a/ir/ir_generator.cpp
+++ b/ir/ir_generator.cpp
@@ -99,14 +99,12 @@ class MethodIRGenerator final : public ast::Visitor {
 
   VISIT_DECL(IntLitExpr, expr,) {
     // TODO: Ensure no overflow.
-    Mem m = builder_.ConstInt32((i32)expr.Value());
-    builder_.Mov(res_, m);
+    builder_.ConstInt32(res_, (i32)expr.Value());
     return VisitResult::SKIP;
   }
 
   VISIT_DECL(BoolLitExpr, expr,) {
-    Mem m = builder_.ConstBool(expr.GetToken().type == lexer::K_TRUE);
-    builder_.Mov(res_, m);
+    builder_.ConstBool(res_, expr.GetToken().type == lexer::K_TRUE);
     return VisitResult::SKIP;
   }
 

--- a/ir/stream_builder.cpp
+++ b/ir/stream_builder.cpp
@@ -83,21 +83,19 @@ void StreamBuilder::EmitLabel(LabelId lid) {
   AppendOp(OpType::LABEL, {lid});
 }
 
-Mem StreamBuilder::Const(SizeClass size, u64 val) {
-  Mem mem = AllocTemp(size);
-
+void StreamBuilder::Const(Mem mem, u64 val) {
   AppendOp(OpType::CONST, {mem.Id(), (u64)mem.Size(), val});
   SetAssigned({mem});
-
-  return mem;
 }
 
-Mem StreamBuilder::ConstInt32(i32 val) {
-  return Const(SizeClass::INT, (u64)(i64)val);
+void StreamBuilder::ConstInt32(Mem mem, i32 val) {
+  CHECK(mem.Size() == SizeClass::INT);
+  Const(mem, (u64)(i64)val);
 }
 
-Mem StreamBuilder::ConstBool(bool b) {
-  return Const(SizeClass::BOOL, b ? 1 : 0);
+void StreamBuilder::ConstBool(Mem mem, bool b) {
+  CHECK(mem.Size() == SizeClass::BOOL);
+  Const(mem, b ? 1 : 0);
 }
 
 void StreamBuilder::Mov(Mem dst, Mem src) {

--- a/ir/stream_builder.h
+++ b/ir/stream_builder.h
@@ -25,11 +25,11 @@ class StreamBuilder {
   // Emit a label as the next instruction.
   void EmitLabel(LabelId);
 
-  // Get a reference to a constant i32 value.
-  Mem ConstInt32(i32);
+  // Writes a constant i32 value to the given Mem.
+  void ConstInt32(Mem, i32);
 
-  // Get a reference to a constant bool value.
-  Mem ConstBool(bool);
+  // Writes a constant bool value to the given Mem.
+  void ConstBool(Mem, bool);
 
   // Emit *dst = *src.
   void Mov(Mem dst, Mem src);
@@ -88,7 +88,7 @@ class StreamBuilder {
   Mem AllocMem(SizeClass, bool);
   void DeallocMem(MemId);
 
-  Mem Const(SizeClass, u64);
+  void Const(Mem, u64);
 
   void AssertAssigned(const std::initializer_list<Mem>& mems) const;
   void SetAssigned(const std::initializer_list<Mem>& mems);


### PR DESCRIPTION
Consts go directly into the address they're needed at.
