### PR TITLE
Make a5 tests work, now that workspace names are a thing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "joosc")
+
 new_git_repository(
     name = "googletest_repo",
     remote = "https://github.com/google/googletest.git",

--- a/marmoset/a5_test.py
+++ b/marmoset/a5_test.py
@@ -28,18 +28,18 @@ test_dir = os.getenv('TEST_SRCDIR', '.')
 def do_test(test_name, test_files):
     shutil.rmtree('output', True)
     os.mkdir('output')
-    shutil.copyfile(test_dir + '/third_party/cs444/stdlib/5.0/runtime.s', 'output/runtime.s')
+    shutil.copyfile(os.path.join(test_dir, 'joosc/third_party/cs444/stdlib/5.0/runtime.s'), 'output/runtime.s')
 
     is_error = "J1e" in test_name
     joosc_args = ['joosc'] + test_files + stdlib_files
-    joosc_args = [os.path.join(test_dir, a) for a in joosc_args]
+    joosc_args = [os.path.join(test_dir, 'joosc', a) for a in joosc_args]
     joosc_proc = subprocess.Popen(joosc_args, stderr=subprocess.STDOUT)
     joosc_proc.wait()
     if joosc_proc.returncode != 0:
         print('\nFailed to compile {}! Ret={}.'.format(test_name, joosc_proc.returncode))
         return False
 
-    asm_proc = subprocess.Popen([test_dir + '/asm.sh'], shell=True, stderr=subprocess.STDOUT)
+    asm_proc = subprocess.Popen([os.path.join(test_dir, 'joosc/asm.sh')], shell=True, stderr=subprocess.STDOUT)
     asm_proc.wait()
     if asm_proc.returncode != 0:
         print('\nFailed to assemble {}! Ret={}.'.format(test_name, asm_proc.returncode))


### PR DESCRIPTION
The runtime/joostests are also broken due to some non-backwards-compatible changes in how java_test works. I'll fix that at some point.

@nelk @jonathanwei 
